### PR TITLE
Remove .JSX import error, component props validation error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,4 +3,11 @@ module.exports = {
   env: {
     browser: true,
   },
+  overrides: [
+    {
+      rules: {
+        'react/prop-types': 'off',
+      },
+    },
+  ],
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,4 +20,7 @@ module.exports = {
       },
     ],
   },
+  resolve: {
+    extensions: ['', '.js', '.jsx'],
+  },
 };


### PR DESCRIPTION
Hey all @svemi @kylemartinelli 
1. I add a new rule in the eslint file to ignore component prop validataion 
2. I add a resolve section in webpack.config.js to solve the jsx import error caused by eslint 
We can talk about this Monday 